### PR TITLE
DB dumper for Laravel 5, only for mySQL db's

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "require": {
         "php" : ">=5.4.0",
         "illuminate/support": "5.0.x",
-        "illuminate/console": "5.0.x"
+        "illuminate/console": "5.0.x",
+        "fabpot/php-cs-fixer": "~1.4"
     },
     "require-dev": {
         "phpunit/phpunit" : "4.*",

--- a/src/Assets/config/laravel-backup.php
+++ b/src/Assets/config/laravel-backup.php
@@ -2,7 +2,7 @@
 <?php
 
 return [
-    'path' => storage_path() . '/db-dumps/',
+    'path' => storage_path().'/db-dumps/',
 
     'mysql' => array(
         'dump_command_path' => '',

--- a/src/Commands/BackupCommand.php
+++ b/src/Commands/BackupCommand.php
@@ -1,29 +1,26 @@
 <?php namespace Spatie\DatabaseBackup\Commands;
 
-use Illuminate\Console\Command;
+use File;
 
-class BackupCommand extends Command
+class BackupCommand extends BaseCommand
 {
     /**
      * The console command name.
      *
      * @var string
      */
-    protected $name = 'db.backup';
+    protected $name = 'db:backup';
+
     /**
      * The console command description.
      *
      * @var string
      */
     protected $description = 'Backup the database to a file';
-    /**
-     * Create a new command instance.
-     *
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
+
+    protected $filePath;
+    protected $fileName;
+
     /**
      * Execute the console command.
      * @return mixed
@@ -31,8 +28,44 @@ class BackupCommand extends Command
      */
     public function fire()
     {
+        $this->info('Starting database dump...');
 
+        $database = $this->getDatabase([]);
+
+        $this->checkDumpFolder();
+
+        $this->fileName = date('YmdHis').'.'.$database->getFileExtension();
+        $this->filePath = rtrim($this->getDumpsPath(), '/').'/'.$this->fileName;
+
+        $status = $database->dump($this->filePath);
+
+        if ($status === true) {
+            $this->info('Database dumped successful in:');
+            $this->comment($this->filePath);
+        }
     }
 
+    protected function getArguments()
+    {
+        return [
+        ];
+    }
 
+    protected function getOptions()
+    {
+        return [
+        ];
+    }
+
+    /**
+     * Checks if dump-folder already exists
+     */
+    protected function checkDumpFolder()
+    {
+        $dumpsPath = $this->getDumpsPath();
+
+        if (!is_dir($dumpsPath)) {
+            mkdir($dumpsPath);
+        }
+    }
 }

--- a/src/Commands/BackupCommand.php
+++ b/src/Commands/BackupCommand.php
@@ -1,7 +1,5 @@
 <?php namespace Spatie\DatabaseBackup\Commands;
 
-use File;
-
 class BackupCommand extends BaseCommand
 {
     /**

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -1,0 +1,46 @@
+<?php namespace Spatie\DatabaseBackup\Commands;
+
+use Illuminate\Console\Command;
+use Spatie\DatabaseBackup\DatabaseBuilder;
+use Spatie\DatabaseBackup\Console;
+use Config;
+
+class BaseCommand extends Command
+{
+
+    protected $databaseBuilder;
+    protected $console;
+
+    public function __construct(DatabaseBuilder $databaseBuilder)
+    {
+        parent::__construct();
+
+        $this->databaseBuilder = $databaseBuilder;
+        $this->console = new Console();
+    }
+
+    /**
+     * Get database configuration
+     *
+     * @param $database
+     * @return mixed
+     * @throws \Exception
+     */
+    public function getDatabase($database)
+    {
+        $database = $database ?: Config::get('database.default');
+        $realConfig = Config::get('database.connections.'.$database);
+
+        return $this->databaseBuilder->getDatabase($realConfig);
+    }
+
+    /**
+     * Gets the path to dump folder from the config
+     *
+     * @return mixed
+     */
+    protected function getDumpsPath()
+    {
+        return Config::get('laravel-backup.path');
+    }
+}

--- a/src/Console.php
+++ b/src/Console.php
@@ -12,12 +12,9 @@ class Console
 
         $process->run();
 
-        if ($process->isSuccessful())
-        {
+        if ($process->isSuccessful()) {
             return true;
-        }
-        else
-        {
+        } else {
             return $process->getErrorOutput();
         }
     }

--- a/src/DatabaseBackupServiceProvider.php
+++ b/src/DatabaseBackupServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\DatabaseBackup;
 
+use DB;
 use Illuminate\Support\ServiceProvider;
 
 class DatabaseBackupServiceProvider extends ServiceProvider
@@ -21,6 +22,9 @@ class DatabaseBackupServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        $this->publishes([
+            __DIR__.'/Assets/config/laravel-backup.php' => config_path('laravel-backup.php'),
+        ]);
     }
 
     /**
@@ -30,13 +34,15 @@ class DatabaseBackupServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app['command.db.backup'] = $this->app->share(
-            function ($app) {
-                return new Commands\BackupCommand();
+        $databaseBuilder = new DatabaseBuilder();
+
+        $this->app['command.db:backup'] = $this->app->share(
+            function ($app) use ($databaseBuilder) {
+                return new Commands\BackupCommand($databaseBuilder);
             }
         );
 
-        $this->commands('command.db.backup');
+        $this->commands('command.db:backup');
     }
 
     /**
@@ -46,6 +52,6 @@ class DatabaseBackupServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return ['command.db.backup'];
+        return ['command.db:backup'];
     }
 }

--- a/src/DatabaseBackupServiceProvider.php
+++ b/src/DatabaseBackupServiceProvider.php
@@ -1,8 +1,5 @@
-<?php
+<?php namespace Spatie\DatabaseBackup;
 
-namespace Spatie\DatabaseBackup;
-
-use DB;
 use Illuminate\Support\ServiceProvider;
 
 class DatabaseBackupServiceProvider extends ServiceProvider

--- a/src/DatabaseBuilder.php
+++ b/src/DatabaseBuilder.php
@@ -1,0 +1,40 @@
+<?php namespace Spatie\DatabaseBackup;
+
+use Exception;
+
+class DatabaseBuilder
+{
+
+    protected $database;
+    protected $console;
+
+    public function __construct()
+    {
+        $this->console = new Console();
+    }
+
+    public function getDatabase(array $realConfig)
+    {
+        try {
+            $this->buildMySQL($realConfig);
+        } catch (Exception $e) {
+            throw new \Exception('Whoops, '.$e->getMessage());
+        }
+
+        return $this->database;
+    }
+
+    protected function buildMySQL(array $config)
+    {
+        $port = isset($config['port']) ? $config['port'] : 3306;
+
+        $this->database = new Databases\MySQLDatabase(
+            $this->console,
+            $config['database'],
+            $config['username'],
+            $config['password'],
+            $config['host'],
+            $port
+        );
+    }
+}

--- a/src/Databases/DatabaseInterface.php
+++ b/src/Databases/DatabaseInterface.php
@@ -25,4 +25,3 @@ interface DatabaseInterface
      */
     public function getFileExtension();
 }
-

--- a/src/Databases/MySQLDatabase.php
+++ b/src/Databases/MySQLDatabase.php
@@ -1,7 +1,6 @@
 <?php namespace Spatie\DatabaseBackup\Databases;
 
 use Spatie\DatabaseBackup\Console;
-
 use Config;
 
 class MySQLDatabase implements DatabaseInterface
@@ -34,6 +33,7 @@ class MySQLDatabase implements DatabaseInterface
             escapeshellarg($this->database),
             escapeshellarg($destinationFile)
         );
+
         return $this->console->run($command);
     }
     public function restore($sourceFile)
@@ -47,6 +47,7 @@ class MySQLDatabase implements DatabaseInterface
             escapeshellarg($this->database),
             escapeshellarg($sourceFile)
         );
+
         return $this->console->run($command);
     }
 
@@ -57,7 +58,6 @@ class MySQLDatabase implements DatabaseInterface
 
     protected function getDumpCommandPath()
     {
-        return Config::get('backup::mysql.dump_command_path');;
+        return Config::get('backup::mysql.dump_command_path');
     }
-
 }


### PR DESCRIPTION
Database dumper for Laravel 5, works only for mySQL databases.
Command is php artisan db:backup