### PR TITLE
Because ClassName::class available only in >= 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php" : ">=5.4.0",
+        "php" : ">=5.5.0",
         "illuminate/support": "5.*",
         "illuminate/console": "5.*",
         "symfony/finder": "~2.6"


### PR DESCRIPTION
BackupCommand.php
line 70: $databaseBackupHandler = app()->make(DatabaseBackupHandler::class);