### PR TITLE
Fix issue when no socket is defined

### DIFF
--- a/src/BackupHandlers/Database/Databases/MySQLDatabase.php
+++ b/src/BackupHandlers/Database/Databases/MySQLDatabase.php
@@ -59,7 +59,7 @@ class MySQLDatabase implements DatabaseInterface
             escapeshellarg($temporaryCredentialsFile),
             escapeshellarg($this->database),
             escapeshellarg($destinationFile),
-            escapeshellarg($this->getSocketArgument())
+            escapeshellcmd($this->getSocketArgument())
         );
 
         return $this->console->run($command);

--- a/tests/database/MySQLDatabaseTest.php
+++ b/tests/database/MySQLDatabaseTest.php
@@ -52,7 +52,7 @@ class MySQLDatabaseTest extends PHPUnit_Framework_TestCase {
             $this->console, 'testDatabase', 'testUser', 'password', 'localhost', '3306', 'customSocket.sock'
         );
         $this->console->shouldReceive('run')
-            ->with("/mysqldump --defaults-extra-file='(.*)' --skip-comments --skip-extended-insert 'testDatabase' > 'testfile.sql' '--socket=customSocket.sock'/")
+            ->with("/mysqldump --defaults-extra-file='(.*)' --skip-comments --skip-extended-insert 'testDatabase' > 'testfile.sql' --socket=customSocket.sock/")
             ->once()
             ->andReturn(true);
 


### PR DESCRIPTION
A client of mine had some issues with this package recently: 

when exporting the database only without any socket defined, the exported file had only one table.